### PR TITLE
Fixed link to BIP39 paper

### DIFF
--- a/README
+++ b/README
@@ -22,7 +22,7 @@ BIP-0032 or similar methods.
 
 ==BIP paper==
 
-See https://github.com/trezor/bips/blob/master/bip-0039.mediawiki for full
+See https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki for full
 specification
 
 ==Reference Implementation==


### PR DESCRIPTION
The link was "...github.com/trezor/..." and it didn't work. I found the BIP39 paper at "...github.com/bitcoin/..." and replaced the link.
