### PR TITLE
Install english.txt (fixes #11)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     url='https://github.com/trezor/python-mnemonic',
     packages=['mnemonic',],
     package_data={'mnemonic': ['wordlist/*.txt']},
+    data_files=[('wordlist', ['mnemonic/wordlist/english.txt'])],
     zip_safe=False,
     install_requires=['pbkdf2'],
     classifiers=[


### PR DESCRIPTION
`data_files` must be specified in `setup.py` to install files into target source tree. `package_data` impacts only files packaged in distributions. (https://docs.python.org/2/distutils/setupscript.html#installing-additional-files)
