### PR TITLE
Removed unnecessary code.

### DIFF
--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -73,7 +73,7 @@ class Mnemonic(object):
 	def generate(self, strength = 128):
 		if strength % 32 > 0:
 			raise Exception('Strength should be divisible by 32, but it is not (%d).' % strength)
-		return self.to_mnemonic(os.urandom(strength // 8))
+		return self.to_mnemonic(os.urandom(strength / 8))
 
 	def to_mnemonic(self, data):
 		if len(data) % 4 > 0:


### PR DESCRIPTION
We already checked that strength is divisible by 32. If strength is divisible by 32, then it must be evenly divisible by 8. Due to this the floor operator is not needed, simple division will suffice. 

Benchmark seen here: 

```david@localhost:~/python-mnemonic$ time python normalDivision1000times.py 

real    0m0.028s
user    0m0.020s
sys     0m0.005s
david@localhost:~/python-mnemonic$ time python floorDivision1000times.py 

real    0m0.052s
user    0m0.040s
sys     0m0.010s```
