### PR TITLE
fix output from generate_vectors.py

### DIFF
--- a/generate_vectors.py
+++ b/generate_vectors.py
@@ -43,4 +43,4 @@ if __name__ == '__main__':
             process(b2h(data), out[lang])
 
     with open('vectors.json', 'w') as f:
-        json.dump(out, f, sort_keys=True, indent=4, separators=(',', ': '))
+        json.dump(out, f, sort_keys=True, indent=4, separators=(',', ': '), ensure_ascii=False)


### PR DESCRIPTION
This problem was causing Japanese to be written to the json file as the ascii characters:
`\u2473` etc.

Using `ensure_ascii=False` will allow for UTF-8 languages to
be generated to vectors.json in UTF-8