### PR TITLE
Fix #22. Add `to_entropy` method which allows one to reverse engineer the...

### DIFF
--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -20,8 +20,10 @@
 #
 
 import binascii
+import bisect
 import hashlib
 import hmac
+import itertools
 import os
 import sys
 import unicodedata
@@ -30,87 +32,130 @@ from pbkdf2 import PBKDF2
 
 PBKDF2_ROUNDS = 2048
 
+class ConfigurationError(Exception):
+    pass
+
+# From <https://stackoverflow.com/questions/212358/binary-search-in-python/2233940#2233940>
+def binary_search(a, x, lo=0, hi=None):   # can't use a to specify default for hi
+    hi = hi if hi is not None else len(a) # hi defaults to len(a)
+    pos = bisect.bisect_left(a,x,lo,hi)   # find insertion position
+    return (pos if pos != hi and a[pos] == x else -1) # don't walk off the end
 
 class Mnemonic(object):
-	def __init__(self, language):
-		self.radix = 2048
-		with open('%s/%s.txt' % (self._get_directory(), language), 'r') as f:
-			self.wordlist = [w.strip() for w in f.readlines()]
-		if len(self.wordlist) != self.radix:
-			raise Exception('Wordlist should contain %d words, but it contains %d words.' % (self.radix, len(self.wordlist)))
+    def __init__(self, language):
+        self.radix = 2048
+        with open('%s/%s.txt' % (self._get_directory(), language), 'r') as f:
+            self.wordlist = [w.strip() for w in f.readlines()]
+        if len(self.wordlist) != self.radix:
+            raise ConfigurationError('Wordlist should contain %d words, but it contains %d words.' % (self.radix, len(self.wordlist)))
 
-	@classmethod
-	def _get_directory(cls):
-		return os.path.join(os.path.dirname(__file__), 'wordlist')
+    @classmethod
+    def _get_directory(cls):
+        return os.path.join(os.path.dirname(__file__), 'wordlist')
 
-	@classmethod
-	def list_languages(cls):
-		return [ f.split('.')[0] for f in os.listdir(cls._get_directory()) if f.endswith('.txt') ]
+    @classmethod
+    def list_languages(cls):
+        return [ f.split('.')[0] for f in os.listdir(cls._get_directory()) if f.endswith('.txt') ]
 
-	@classmethod
-	def normalize_string(cls, txt):
-		if isinstance(txt, str if sys.version < '3' else bytes):
-			utxt = txt.decode('utf8')
-		elif isinstance(txt, unicode if sys.version < '3' else str):
-			utxt = txt
-		else:
-			raise Exception("String value expected")
+    @classmethod
+    def normalize_string(cls, txt):
+        if isinstance(txt, str if sys.version < '3' else bytes):
+            utxt = txt.decode('utf8')
+        elif isinstance(txt, unicode if sys.version < '3' else str):
+            utxt = txt
+        else:
+            raise TypeError("String value expected")
 
-		return unicodedata.normalize('NFKD', utxt)
+        return unicodedata.normalize('NFKD', utxt)
 
-	@classmethod
-	def detect_language(cls, code):
-		first = code.split(' ')[0]
-		languages = cls.list_languages()
+    @classmethod
+    def detect_language(cls, code):
+        first = code.split(' ')[0]
+        languages = cls.list_languages()
 
-		for lang in languages:
-			mnemo = cls(lang)
-			if first in mnemo.wordlist:
-				return lang
+        for lang in languages:
+            mnemo = cls(lang)
+            if first in mnemo.wordlist:
+                return lang
 
-		raise Exception("Language not detected")
+        raise ConfigurationError("Language not detected")
 
-	def generate(self, strength = 128):
-		if strength % 32 > 0:
-			raise Exception('Strength should be divisible by 32, but it is not (%d).' % strength)
-		return self.to_mnemonic(os.urandom(strength // 8))
+    def generate(self, strength = 128):
+        if strength % 32 > 0:
+            raise ValueError('Strength should be divisible by 32, but it is not (%d).' % strength)
+        return self.to_mnemonic(os.urandom(strength // 8))
 
-	def to_mnemonic(self, data):
-		if len(data) % 4 > 0:
-			raise Exception('Data length in bits should be divisible by 32, but it is not (%d bytes = %d bits).' % (len(data), len(data) * 8))
-		h = hashlib.sha256(data).hexdigest()
-		b = bin(int(binascii.hexlify(data), 16))[2:].zfill(len(data) * 8) + \
-		    bin(int(h, 16))[2:].zfill(256)[:len(data) * 8 // 32]
-		result = []
-		for i in range(len(b) // 11):
-			idx = int(b[i * 11:(i + 1) * 11], 2)
-			result.append(self.wordlist[idx])
-		if self.detect_language(' '.join(result)) == 'japanese': # Japanese must be joined by ideographic space.
-			result_phrase = '\xe3\x80\x80'.join(result)
-		else:
-			result_phrase = ' '.join(result)
-		return result_phrase
+    def to_entropy(self, words):
+        # Adapted from <http://tinyurl.com/oxmn476>
+        if len(words) % 3 > 0:
+            raise ValueError('Word list size must be multiple of three words.')
+        # Look up all the words in the list and construct the
+        # concatenation of the original entropy and the checksum.
+        concatLenBits = len(words) * 11
+        concatBits = [ False ] * concatLenBits
+        wordindex = 0
+        for word in words:
+            # Find the words index in the wordlist
+            ndx = binary_search(self.wordlist, word)
+            if ndx < 0:
+                raise LookupError('Unable to find "%s" in word list.' % word)
+            # Set the next 11 bits to the value of the index.
+            for ii in range(11):
+                concatBits[(wordindex * 11) + ii] = (ndx & (1 << (10 - ii))) != 0
+            wordindex += 1
+        checksumLengthBits = concatLenBits // 33
+        entropyLengthBits = concatLenBits - checksumLengthBits
+        # Extract original entropy as bytes.
+        entropy = bytearray(entropyLengthBits // 8)
+        for ii in range(len(entropy)):
+            for jj in range(8):
+                if concatBits[(ii * 8) + jj]:
+                    entropy[ii] |= 1 << (7 - jj)
+        # Take the digest of the entropy.
+        hashBytes = hashlib.sha256(entropy).digest()
+        hashBits = list(itertools.chain.from_iterable(( [ ord(c) & (1 << (7 - i)) != 0 for i in range(8) ] for c in hashBytes )))
+        # Check all the checksum bits.
+        for i in range(checksumLengthBits):
+            if concatBits[entropyLengthBits + i] != hashBits[i]:
+                raise ValueError('Failed checksum.')
+        return entropy
 
-	def check(self, mnemonic):
-		if self.detect_language(mnemonic.replace('\xe3\x80\x80', ' ')) == 'japanese':
-			mnemonic = mnemonic.replace('\xe3\x80\x80', ' ') # Japanese will likely input with ideographic space.
-		mnemonic = mnemonic.split(' ')
-		if len(mnemonic) % 3 > 0:
-			return False
-		try:
-			idx = map(lambda x: bin(self.wordlist.index(x))[2:].zfill(11), mnemonic)
-			b = ''.join(idx)
-		except:
-			return False
-		l = len(b)
-		d = b[:l // 33 * 32]
-		h = b[-l // 33:]
-		nd = binascii.unhexlify(hex(int(d, 2))[2:].rstrip('L').zfill(l // 33 * 8))
-		nh = bin(int(hashlib.sha256(nd).hexdigest(), 16))[2:].zfill(256)[:l // 33]
-		return h == nh
+    def to_mnemonic(self, data):
+        if len(data) % 4 > 0:
+            raise ValueError('Data length in bits should be divisible by 32, but it is not (%d bytes = %d bits).' % (len(data), len(data) * 8))
+        h = hashlib.sha256(data).hexdigest()
+        b = bin(int(binascii.hexlify(data), 16))[2:].zfill(len(data) * 8) + \
+            bin(int(h, 16))[2:].zfill(256)[:len(data) * 8 // 32]
+        result = []
+        for i in range(len(b) // 11):
+            idx = int(b[i * 11:(i + 1) * 11], 2)
+            result.append(self.wordlist[idx])
+        if self.detect_language(' '.join(result)) == 'japanese': # Japanese must be joined by ideographic space.
+            result_phrase = '\xe3\x80\x80'.join(result)
+        else:
+            result_phrase = ' '.join(result)
+        return result_phrase
 
-	@classmethod
-	def to_seed(cls, mnemonic, passphrase = ''):
-		mnemonic = cls.normalize_string(mnemonic)
-		passphrase = cls.normalize_string(passphrase)
-		return PBKDF2(mnemonic, u'mnemonic' + passphrase, iterations=PBKDF2_ROUNDS, macmodule=hmac, digestmodule=hashlib.sha512).read(64)
+    def check(self, mnemonic):
+        if self.detect_language(mnemonic.replace('\xe3\x80\x80', ' ')) == 'japanese':
+            mnemonic = mnemonic.replace('\xe3\x80\x80', ' ') # Japanese will likely input with ideographic space.
+        mnemonic = mnemonic.split(' ')
+        if len(mnemonic) % 3 > 0:
+            return False
+        try:
+            idx = map(lambda x: bin(self.wordlist.index(x))[2:].zfill(11), mnemonic)
+            b = ''.join(idx)
+        except:
+            return False
+        l = len(b)
+        d = b[:l // 33 * 32]
+        h = b[-l // 33:]
+        nd = binascii.unhexlify(hex(int(d, 2))[2:].rstrip('L').zfill(l // 33 * 8))
+        nh = bin(int(hashlib.sha256(nd).hexdigest(), 16))[2:].zfill(256)[:l // 33]
+        return h == nh
+
+    @classmethod
+    def to_seed(cls, mnemonic, passphrase = ''):
+        mnemonic = cls.normalize_string(mnemonic)
+        passphrase = cls.normalize_string(passphrase)
+        return PBKDF2(mnemonic, u'mnemonic' + passphrase, iterations=PBKDF2_ROUNDS, macmodule=hmac, digestmodule=hashlib.sha512).read(64)

--- a/test_mnemonic.py
+++ b/test_mnemonic.py
@@ -22,10 +22,9 @@
 
 from __future__ import print_function
 
-import hashlib
 import json
+import random
 import sys
-import unicodedata
 import unittest
 from binascii import hexlify, unhexlify
 
@@ -62,7 +61,7 @@ class MnemonicTest(unittest.TestCase):
             Mnemonic.detect_language('xxxxxxx')
 
     def test_collision(self):
-        # Check for the same words accross wordlists.
+        # Check for the same words across wordlists.
         # This is prohibited because of auto-detection feature of language.
 
         words = []
@@ -188,7 +187,7 @@ class MnemonicTest(unittest.TestCase):
                             print("Similar words (%s): %s, %s" % (lang, w1, w2))
 
         if fail:
-            self.assert_(False, "Similar words found")
+            self.fail("Similar words found")
 
     def test_utf8_nfkd(self):
         # The same sentence in various UTF-8 forms
@@ -210,6 +209,13 @@ class MnemonicTest(unittest.TestCase):
         self.assertEqual(seed_nfkd, seed_nfc)
         self.assertEqual(seed_nfkd, seed_nfkc)
         self.assertEqual(seed_nfkd, seed_nfd)
+
+    def test_to_entropy(self):
+        data = [ bytearray(( random.getrandbits(8) for _ in range(32) )) for _ in range(1024) ]
+        data.append(" I'm a little teapot, short and stout. Here is my handle. Here is my spout. When I get all steamed up, hear me shout. Tip me over and pour me out!! ")
+        m = Mnemonic('english')
+        for d in data:
+            self.assertEqual(m.to_entropy(m.to_mnemonic(d).split()), d)
 
 def __main__():
     unittest.main()


### PR DESCRIPTION
...original entropy data. Includes minor code fixes, such as converting tabs -> spaces in `mnemonic.py` (per [PEP 8](https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces)).

Also, I made the `Exception`s raised more specific to the types of errors encountered in various places. In addition, this PR includes an additional unit test for the new `to_entropy` method.

**WARNING**: this is pretty much a verbatim translation from [this Java implementation](https://github.com/bitcoinj/bitcoinj/blob/6aa4e51de6004f7171802bbce9c1660228d05aae/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java#L147). While technically correct, there might be *much* more efficient ways of doing this in python. I have not spent any time optimizing.

Now one can do something like this to pull out the original entropy:

```python
>>> m = Mnemonic('english')
>>> w = m.to_mnemonic("She sells sea shells down by the sea shore?!")
>>> w
'fat drip elite traffic fine curtain smart attack grace animal broom speak fine curtain smart arrive hunt rocket marine shaft must demand pave piano inflict climb elite traffic manage rice neutral tomorrow entry'
>>> m.to_entropy(w.split())
bytearray(b'She sells sea shells down by the sea shore?!')
```