### PR TITLE
expand unique mnemonic word prefix matches for cryptosteel-like use cases

### DIFF
--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2013 Pavol Rusnak
+# Copyright (c) 2017 mruddy
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -157,6 +158,23 @@ class Mnemonic(object):
         nd = binascii.unhexlify(hex(int(d, 2))[2:].rstrip('L').zfill(l // 33 * 8))
         nh = bin(int(hashlib.sha256(nd).hexdigest(), 16))[2:].zfill(256)[:l // 33]
         return h == nh
+
+    def expand_word(self, prefix):
+        if prefix in self.wordlist:
+            return prefix
+        else:
+            matches = [word for word in self.wordlist if word.startswith(prefix)]
+            if len(matches) == 1: # matched exactly one word in the wordlist
+                return matches[0]
+            else:
+                # exact match not found.
+                # this is not a validation routine, just return the input
+                return prefix
+
+    def expand(self, mnemonic):
+        if self.detect_language(mnemonic.replace(u'\xe3\x80\x80', ' ')) == 'japanese':
+            mnemonic = mnemonic.replace(u'\xe3\x80\x80', ' ') # Japanese will likely input with ideographic space.
+        return ' '.join(map(self.expand_word, mnemonic.split(' ')))
 
     @classmethod
     def to_seed(cls, mnemonic, passphrase=''):

--- a/test_mnemonic.py
+++ b/test_mnemonic.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Copyright (c) 2013 Pavol Rusnak
+# Copyright (c) 2017 mruddy
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -220,6 +221,22 @@ class MnemonicTest(unittest.TestCase):
         m = Mnemonic('english')
         for d in data:
             self.assertEqual(m.to_entropy(m.to_mnemonic(d).split()), d)
+
+    def test_expand_word(self):
+        m = Mnemonic('english')
+        self.assertEqual('', m.expand_word(''))
+        self.assertEqual(' ', m.expand_word(' '))
+        self.assertEqual('access', m.expand_word('access')) # word in list
+        self.assertEqual('access', m.expand_word('acce')) # unique prefix expanded to word in list
+        self.assertEqual('acb', m.expand_word('acb')) # not found at all
+        self.assertEqual('acc', m.expand_word('acc')) # multi-prefix match
+        self.assertEqual('act', m.expand_word('act')) # exact three letter match
+        self.assertEqual('action', m.expand_word('acti')) # unique prefix expanded to word in list
+
+    def test_expand(self):
+        m = Mnemonic('english')
+        self.assertEqual('access', m.expand('access'))
+        self.assertEqual('access access acb acc act action', m.expand('access acce acb acc act acti'))
 
 def __main__():
     unittest.main()


### PR DESCRIPTION
Work in progress: I wanted to get feedback on an idea. As such, it might not be ready to merge yet.

Basically, this makes it easier for a cryptosteel + tails live cd style use case where you have a mnemonic word set saved, but with only the required four letters per word (for languages supporting this property), and you want to load your Trezor with it easily without having to use a tool, or do manual word lookups.

Running the proposed expansion would allow a user to do something like:
```trezorctl load_device -m 'all also alph wres ...'```

If their mnemonic word set started with "all also alpha wrestle"

An accompanying patch to ```python-trezor/trezorlib/client.py``` would be something like [this diff](https://github.com/trezor/python-trezor/compare/master...mruddy:fix2)
```
        m = Mnemonic('english')
+       mnemonic = m.prefix_expand(mnemonic)
        if not skip_checksum and not m.check(mnemonic):
```