### PR TITLE
fix #29: store decoded and NFKD normalized words in the wordlist

### DIFF
--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -45,7 +45,7 @@ class Mnemonic(object):
     def __init__(self, language):
         self.radix = 2048
         with open('%s/%s.txt' % (self._get_directory(), language), 'r') as f:
-            self.wordlist = [w.strip() for w in f.readlines()]
+            self.wordlist = [Mnemonic.normalize_string(w.strip()) for w in f.readlines()]
         if len(self.wordlist) != self.radix:
             raise ConfigurationError('Wordlist should contain %d words, but it contains %d words.' % (self.radix, len(self.wordlist)))
 


### PR DESCRIPTION
This addresses https://github.com/trezor/python-mnemonic/issues/29

@dooglus's assessment of the problem looks correct. This PR just implements his proposed fix.

This only affected Python 2 for Japanese as far as I could tell.

I tested some and this seems to work. Perhaps give a day or two for some more testing before merging since this stuff is a little confusing. Specifically, I want to review how this could interact with the trezorlib/client.py code that does NFC normalization (everything in [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) states NFKD).