### PR TITLE
fix bug expanding first word that fails language detection

### DIFF
--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -172,8 +172,6 @@ class Mnemonic(object):
                 return prefix
 
     def expand(self, mnemonic):
-        if self.detect_language(mnemonic.replace(u'\xe3\x80\x80', ' ')) == 'japanese':
-            mnemonic = mnemonic.replace(u'\xe3\x80\x80', ' ') # Japanese will likely input with ideographic space.
         return ' '.join(map(self.expand_word, mnemonic.split(' ')))
 
     @classmethod


### PR DESCRIPTION
i found a bug with the word expansion stuff that i added.

if the first word needs expansion, language detection fails.

this fix removes the japanese support during expansion. the client code that uses it uses a fixed english mnemonic anyways. this language support can be added later once all that stuff is a little cleaner.

reproduce with:
```
trezorctl load_device -e -m 'aban abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
```

i think after this gets merged and updated in pypi, i'll ping the debian package maintainer to see about getting python-mnemonic and python-trezor packages updated.