### PR TITLE
Japanese language fixes.

### DIFF
--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -73,6 +73,7 @@ class Mnemonic(object):
 
     @classmethod
     def detect_language(cls, code):
+        code = cls.normalize_string(code)
         first = code.split(' ')[0]
         languages = cls.list_languages()
 

--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -100,9 +100,13 @@ class Mnemonic(object):
         concatLenBits = len(words) * 11
         concatBits = [False] * concatLenBits
         wordindex = 0
+        if self.detect_language(' '.join(words)) == 'english':
+            use_binary_search = True
+        else:
+            use_binary_search = False
         for word in words:
             # Find the words index in the wordlist
-            ndx = binary_search(self.wordlist, word)
+            ndx = binary_search(self.wordlist, word) if use_binary_search else self.wordlist.index(word)
             if ndx < 0:
                 raise LookupError('Unable to find "%s" in word list.' % word)
             # Set the next 11 bits to the value of the index.

--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -48,7 +48,7 @@ class Mnemonic(object):
     def __init__(self, language):
         self.radix = 2048
         with open('%s/%s.txt' % (self._get_directory(), language), 'r') as f:
-            self.wordlist = [w.strip() for w in f.readlines()]
+            self.wordlist = [w.strip().decode('utf8') if sys.version < '3' else w.strip() for w in f.readlines()]
         if len(self.wordlist) != self.radix:
             raise ConfigurationError('Wordlist should contain %d words, but it contains %d words.' % (self.radix, len(self.wordlist)))
 

--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -140,15 +140,13 @@ class Mnemonic(object):
             idx = int(b[i * 11:(i + 1) * 11], 2)
             result.append(self.wordlist[idx])
         if self.detect_language(' '.join(result)) == 'japanese':  # Japanese must be joined by ideographic space.
-            result_phrase = u'\xe3\x80\x80'.join(result)
+            result_phrase = u'　'.join(result)
         else:
             result_phrase = ' '.join(result)
         return result_phrase
 
     def check(self, mnemonic):
-        if self.detect_language(mnemonic.replace(u'\xe3\x80\x80', ' ')) == 'japanese':
-            mnemonic = mnemonic.replace(u'\xe3\x80\x80', ' ')  # Japanese will likely input with ideographic space.
-        mnemonic = mnemonic.split(' ')
+        mnemonic = self.normalize_string(mnemonic).split(' ')
         if len(mnemonic) % 3 > 0:
             return False
         try:

--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -140,7 +140,7 @@ class Mnemonic(object):
             idx = int(b[i * 11:(i + 1) * 11], 2)
             result.append(self.wordlist[idx])
         if self.detect_language(' '.join(result)) == 'japanese':  # Japanese must be joined by ideographic space.
-            result_phrase = u'　'.join(result)
+            result_phrase = u'\u3000'.join(result)
         else:
             result_phrase = ' '.join(result)
         return result_phrase


### PR DESCRIPTION
Detect language was not working. Turns out Python2 reads files as bytestrings and so you must decode UTF8 bytes into a unicode object.

Also, since Japanese typed by normal keyboard is not normalized by default, we must normalize before comparing the wordlist (assumes each wordlist is uploaded as pre-normalized words separated by \n.

These changes do not affect English, as all English normalized is the same.

I have tested these changes on Python3 and 2 and found no problem.