### PR TITLE
fixed check() so it will return False on certain invalid mnemonics

### DIFF
--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -151,7 +151,8 @@ class Mnemonic(object):
 
     def check(self, mnemonic):
         mnemonic = self.normalize_string(mnemonic).split(' ')
-        if len(mnemonic) % 3 > 0:
+        # list of valid mnemonic lengths
+        if len(mnemonic) not in [12, 15, 18, 21, 24]:
             return False
         try:
             idx = map(lambda x: bin(self.wordlist.index(x))[2:].zfill(11), mnemonic)


### PR DESCRIPTION
Previously a mnemonic such as 'winner thank yellow' would return True because len(mnemonic) % 3 == 0. Now check() will compare len(mnemonic) to a list of all valid lengths