### PR TITLE
Require explicit Optional in type annotations

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -9,6 +9,7 @@ disallow_untyped_defs = True
 check_untyped_defs = True
 strict_equality = True
 implicit_reexport = False
+no_implicit_optional = True
 
 [mypy-generate_vectors]
 ignore_errors = True

--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -25,7 +25,7 @@ import hashlib
 import hmac
 import itertools
 import os
-from typing import AnyStr, List, Sequence, TypeVar, Union
+from typing import AnyStr, List, Optional, Sequence, TypeVar, Union
 import unicodedata
 
 _T = TypeVar("_T")
@@ -41,7 +41,7 @@ def binary_search(
     a: Sequence[_T],
     x: _T,
     lo: int = 0,
-    hi: int = None,  # can't use a to specify default for hi
+    hi: Optional[int] = None,  # can't use a to specify default for hi
 ) -> int:
     hi = hi if hi is not None else len(a)  # hi defaults to len(a)
     pos = bisect.bisect_left(a, x, lo, hi)  # find insertion position


### PR DESCRIPTION
This PR disables the "implicit optional" mypy feature. Type annotations relying on it are no longer PEP 484 compliant (see https://github.com/python/peps/pull/689). Mypy will also turn the feature off in a future release (see https://github.com/python/mypy/issues/9091).