### PR TITLE
Change encoding used to read wordlist files to recognize BOM

### DIFF
--- a/mnemonic/mnemonic.py
+++ b/mnemonic/mnemonic.py
@@ -68,7 +68,7 @@ class Mnemonic(object):
     def __init__(self, language: str):
         self.radix = 2048
         with open(
-            "%s/%s.txt" % (self._get_directory(), language), "r", encoding="utf-8"
+            "%s/%s.txt" % (self._get_directory(), language), "r", encoding="utf-8-sig"
         ) as f:
             self.wordlist = [w.strip() for w in f.readlines()]
         if len(self.wordlist) != self.radix:


### PR DESCRIPTION
The Unicode encoding UTF-8 allows an optional character at the beginning
of the file called the "byte order mark", or BOM.  In UTF-16 or UTF-32,
this character represents whether the byte order of characters is big-
endian or little-endian.  The UTF-8 standard does not require or
recommend the use of a BOM; however, a BOM may still be included in
UTF-8 files for a number of reasons.

The BIP-39 wordlist file `french.txt` currently includes the byte order
mark `U+FEFF` at the beginning of the file.  The encoding method used in
`Mnemonic.__init__` to read this file is 'utf-8', which does not parse
any BOM at the beginning of a file, and thus produces a Python list with
first entry '\ufeffabaisser' instead of the correct string 'abaisser'.
This in particular results in valid French mnemonic seed phrases
starting with 'abaisser' to be incorrectly rejected by the
`Mnemonic.check` validation function.

The commit in this pull request changes the encoding method used to
read the wordlist from 'utf-8' to 'utf-8-sig', which causes Python to
properly interpret BOM characters in UTF-8 files, and fixes the incorrect
first entry in the French language `Mnemonic` object's wordlist.
