### PR TITLE
Use secrets module

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy-3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.5",
+    python_requires=">=3.7",
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX :: Linux",

--- a/src/mnemonic/mnemonic.py
+++ b/src/mnemonic/mnemonic.py
@@ -25,8 +25,9 @@ import hashlib
 import hmac
 import itertools
 import os
-from typing import AnyStr, List, Optional, Sequence, TypeVar, Union
+import secrets
 import unicodedata
+from typing import AnyStr, List, Optional, Sequence, TypeVar, Union
 
 _T = TypeVar("_T")
 PBKDF2_ROUNDS = 2048
@@ -115,12 +116,26 @@ class Mnemonic(object):
         raise ConfigurationError("Language not detected")
 
     def generate(self, strength: int = 128) -> str:
+        """
+        Create a new mnemonic using a random generated number as entropy.
+
+        As defined in BIP39, the entropy must be a multiple of 32 bits, and its size must be between 128 and 256 bits.
+        Therefore the possible values for `strength` are 128, 160, 192, 224 and 256.
+
+        If not provided, the default entropy length will be set to 128 bits.
+
+        The return is a list of words that encodes the entropy generated.
+
+        :param strength: Number of bytes used as entropy
+        :type strength: int
+        :return: A randomly generated mnemonic
+        :rtype: str
+        """
         if strength not in [128, 160, 192, 224, 256]:
             raise ValueError(
-                "Strength should be one of the following [128, 160, 192, 224, 256], but it is not (%d)."
-                % strength
+                "Invalid strength value. Allowed values are [128, 160, 192, 224, 256]."
             )
-        return self.to_mnemonic(os.urandom(strength // 8))
+        return self.to_mnemonic(secrets.token_bytes(strength // 8))
 
     # Adapted from <http://tinyurl.com/oxmn476>
     def to_entropy(self, words: Union[List[str], str]) -> bytearray:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
 envlist =
-    py35,
-    py36,
     py37,
     py38,
     py39,


### PR DESCRIPTION
As per Python [documentation]([url](https://docs.python.org/3/library/secrets.html)):

> In particular, secrets should be used in preference to the default pseudo-random number generator in the random module, which is designed for modeling and simulation, not security or cryptography.

> The secrets module provides access to the most secure source of randomness that your operating system provides.

Additionally:
- Setting English as the default language straight in the __init__ function
- Checking for the existence of the dictionary file before attempting to open it