### PR TITLE
Detect language unambiguously, or raise explanatory exception

### DIFF
--- a/src/mnemonic/mnemonic.py
+++ b/src/mnemonic/mnemonic.py
@@ -107,10 +107,10 @@ class Mnemonic(object):
         for word in code.split():
             possible = set(p for p in possible if word in p.wordlist)
             if not possible:
-                raise ConfigurationError(f"Language unrecognized: {word!r}")
+                raise ConfigurationError(f"Language unrecognized for {word!r}")
         if len( possible ) == 1:
             return possible.pop().language
-        raise ConfigurationError(f"Language ambiguous: {', '.join( p.language for p in possible)}")
+        raise ConfigurationError(f"Language ambiguous between {', '.join( p.language for p in possible)}")
 
     def generate(self, strength: int = 128) -> str:
         """

--- a/src/mnemonic/mnemonic.py
+++ b/src/mnemonic/mnemonic.py
@@ -101,16 +101,16 @@ class Mnemonic(object):
 
     @classmethod
     def detect_language(cls, code: str) -> str:
+        """Scan the Mnemonic until the language becomes unambiguous."""
         code = cls.normalize_string(code)
-        first = code.split(" ")[0]
-        languages = cls.list_languages()
-
-        for lang in languages:
-            mnemo = cls(lang)
-            if first in mnemo.wordlist:
-                return lang
-
-        raise ConfigurationError("Language not detected")
+        possible = set(cls(lang) for lang in cls.list_languages())
+        for word in code.split():
+            possible = set(p for p in possible if word in p.wordlist)
+            if not possible:
+                raise ConfigurationError(f"Language unrecognized: {word!r}")
+        if len( possible ) == 1:
+            return possible.pop().language
+        raise ConfigurationError(f"Language ambiguous: {', '.join( p.language for p in possible)}")
 
     def generate(self, strength: int = 128) -> str:
         """

--- a/src/mnemonic/mnemonic.py
+++ b/src/mnemonic/mnemonic.py
@@ -108,9 +108,11 @@ class Mnemonic(object):
             possible = set(p for p in possible if word in p.wordlist)
             if not possible:
                 raise ConfigurationError(f"Language unrecognized for {word!r}")
-        if len( possible ) == 1:
+        if len(possible) == 1:
             return possible.pop().language
-        raise ConfigurationError(f"Language ambiguous between {', '.join( p.language for p in possible)}")
+        raise ConfigurationError(
+            f"Language ambiguous between {', '.join( p.language for p in possible)}"
+        )
 
     def generate(self, strength: int = 128) -> str:
         """

--- a/tests/test_mnemonic.py
+++ b/tests/test_mnemonic.py
@@ -58,10 +58,14 @@ class MnemonicTest(unittest.TestCase):
         self.assertEqual("english", Mnemonic.detect_language("security"))
 
         with self.assertRaises(Exception):
-            Mnemonic.detect_language("jaguar xxxxxxx") # Unrecognized in any known language
+            Mnemonic.detect_language(
+                "jaguar xxxxxxx"
+            )  # Unrecognized in any known language
 
         with self.assertRaises(Exception):
-            Mnemonic.detect_language("jaguar jaguar") # Ambiguous after examining all words
+            Mnemonic.detect_language(
+                "jaguar jaguar"
+            )  # Ambiguous after examining all words
 
         self.assertEqual("english", Mnemonic.detect_language("jaguar security"))
         self.assertEqual("french", Mnemonic.detect_language("jaguar aboyer"))

--- a/tests/test_mnemonic.py
+++ b/tests/test_mnemonic.py
@@ -58,7 +58,13 @@ class MnemonicTest(unittest.TestCase):
         self.assertEqual("english", Mnemonic.detect_language("security"))
 
         with self.assertRaises(Exception):
-            Mnemonic.detect_language("xxxxxxx")
+            Mnemonic.detect_language("jaguar xxxxxxx") # Unrecognized in any known language
+
+        with self.assertRaises(Exception):
+            Mnemonic.detect_language("jaguar jaguar") # Ambiguous after examining all words
+
+        self.assertEqual("english", Mnemonic.detect_language("jaguar security"))
+        self.assertEqual("french", Mnemonic.detect_language("jaguar aboyer"))
 
     def test_utf8_nfkd(self) -> None:
         # The same sentence in various UTF-8 forms


### PR DESCRIPTION
Correctly and unambiguously determine Mnemonic language.

@prusnak, perhaps this is sufficiently clear that it doesn't make the reference implementation less tidy?