### PR TITLE
Support unambiguous detection of language if only prefixes are supplied

### DIFF
--- a/src/mnemonic/mnemonic.py
+++ b/src/mnemonic/mnemonic.py
@@ -96,12 +96,10 @@ class Mnemonic(object):
         for word in code.split():
             # possible languages have candidate(s) starting with the word/prefix
             possible = set(p for p in possible if any(c.startswith( word ) for c in p.wordlist))
+            if len(possible) == 1:
+                return possible.pop().language
             if not possible:
                 raise ConfigurationError(f"Language unrecognized for {word!r}")
-            if len( possible ) < 2:
-                break
-        if len(possible) == 1:
-            return possible.pop().language
         raise ConfigurationError(
             f"Language ambiguous between {', '.join( p.language for p in possible)}"
         )

--- a/src/mnemonic/mnemonic.py
+++ b/src/mnemonic/mnemonic.py
@@ -90,13 +90,16 @@ class Mnemonic(object):
 
     @classmethod
     def detect_language(cls, code: str) -> str:
-        """Scan the Mnemonic until the language becomes unambiguous."""
+        """Scan the Mnemonic until the language becomes unambiguous, including as abbreviation prefixes."""
         code = cls.normalize_string(code)
         possible = set(cls(lang) for lang in cls.list_languages())
         for word in code.split():
-            possible = set(p for p in possible if word in p.wordlist)
+            # possible languages have candidate(s) starting with the word/prefix
+            possible = set(p for p in possible if any(c.startswith( word ) for c in p.wordlist))
             if not possible:
                 raise ConfigurationError(f"Language unrecognized for {word!r}")
+            if len( possible ) < 2:
+                break
         if len(possible) == 1:
             return possible.pop().language
         raise ConfigurationError(

--- a/tests/test_mnemonic.py
+++ b/tests/test_mnemonic.py
@@ -71,8 +71,20 @@ class MnemonicTest(unittest.TestCase):
                 "jaguar jaguar"
             )  # Ambiguous after examining all words
 
+        # Allowing word prefixes in language detection presents ambiguity issues.  Require exactly
+        # one language that matches all prefixes, or one language matching some word(s) exactly.
         self.assertEqual("english", Mnemonic.detect_language("jaguar security"))
         self.assertEqual("french", Mnemonic.detect_language("jaguar aboyer"))
+        self.assertEqual("english", Mnemonic.detect_language("abandon about"))
+        self.assertEqual("french", Mnemonic.detect_language("abandon aboutir"))
+        self.assertEqual("french", Mnemonic.detect_language("fav financer"))
+        self.assertEqual("czech", Mnemonic.detect_language("fav finance"))
+        with self.assertRaises(Exception):
+            Mnemonic.detect_language("favor finan")
+        self.assertEqual("czech", Mnemonic.detect_language("flanel"))
+        self.assertEqual("portuguese", Mnemonic.detect_language("flanela"))
+        with self.assertRaises(Exception):
+            Mnemonic.detect_language("flane")
 
     def test_utf8_nfkd(self) -> None:
         # The same sentence in various UTF-8 forms

--- a/tests/test_mnemonic.py
+++ b/tests/test_mnemonic.py
@@ -57,6 +57,10 @@ class MnemonicTest(unittest.TestCase):
     def test_detection(self) -> None:
         self.assertEqual("english", Mnemonic.detect_language("security"))
 
+        self.assertEqual( "english", Mnemonic.detect_language( "fruit wave dwarf" ))  # ambiguous up to wave
+        self.assertEqual( "english", Mnemonic.detect_language( "fru wago dw" ))  # ambiguous french/english up to dwarf prefix
+        self.assertEqual( "french", Mnemonic.detect_language( "fru wago dur enje" ))  # ambiguous french/english up to enjeu prefix
+
         with self.assertRaises(Exception):
             Mnemonic.detect_language(
                 "jaguar xxxxxxx"


### PR DESCRIPTION
If a BIP-39 Mnemonic is supplied that contains word prefixes (such as would be resolved by calling Mnemonic.expand), the Mnemonic.detect_language function fails.  This fix simply allows detect_language to proceed until the prefix no longer appears in multiple language dictionaries.

Also, we detect that ambiguity no longer exists (less than 2 languages remain), and we suspend t the search.

Tests added to confirm that the search proceeds in the face of prefixes available in multiple languages.