### PR TITLE
Use the normalize_string function when reading mnemonic words

### DIFF
--- a/src/mnemonic/mnemonic.py
+++ b/src/mnemonic/mnemonic.py
@@ -141,7 +141,7 @@ class Mnemonic(object):
         wordindex = 0
         for word in words:
             # Find the words index in the wordlist
-            ndx = self.wordlist.index(word)
+            ndx = self.wordlist.index(self.normalize_string(word))
             if ndx < 0:
                 raise LookupError('Unable to find "%s" in word list.' % word)
             # Set the next 11 bits to the value of the index.


### PR DESCRIPTION
I created a mnemonic word using the `to_mnemonic` function of the module you created. However, I entered the mnemonic word as a parameter of the `to_entropy` function to regenerate a private key again later, but got a `ValueError: myword is not in list`.

As it turns out, the environment in which I type the mnemonic words used `NFC` method, and the module you created used the word in the `NFKD` method. Therefore, when reading the word in the `to_entropy` function, I suggest that it is always normalized with the `NFKD` method through the `normalize_string` function.

Thanks for reading this.