### PR TITLE
Add CLI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,9 +22,14 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install package
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
+        python -m pip install --upgrade build pip setuptools
         python -m pip install .
     - name: Run test
       run: |
         python tests/test_mnemonic.py
+    - name: Build wheel and sdist
+      run: |
+        python -m build
+    - name: Check long description
+      run: |
+        twine check dist/*

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install package
       run: |
-        python -m pip install --upgrade build pip setuptools
+        python -m pip install --upgrade build pip setuptools twine
         python -m pip install .
     - name: Run test
       run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,17 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to
 `Semantic Versioning`_.
 
+`0.22`_ - Unreleased
+--------------------
+
+.. _0.22: https://github.com/trezor/python-mnemonic/compare/v0.21...HEAD
+
+Added
+~~~~~
+
+- Command-line interface with ``create``, ``check``, and ``to-seed`` commands
+- Click as a runtime dependency
+
 `0.21`_ - 2024-01-05
 --------------------
 

--- a/README.rst
+++ b/README.rst
@@ -13,22 +13,23 @@ Abstract
 This BIP describes the implementation of a mnemonic code or mnemonic sentence --
 a group of easy to remember words -- for the generation of deterministic wallets.
 
-It consists of two parts: generating the mnenomic, and converting it into a
+It consists of two parts: generating the mnemonic, and converting it into a
 binary seed. This seed can be later used to generate deterministic wallets using
 BIP-0032 or similar methods.
 
 BIP Paper
 ---------
 
-See https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
-for full specification
+See `BIP-0039`_ for the full specification.
 
 Installation
 ------------
 
 To install this library and its dependencies use:
 
- ``pip install mnemonic``
+.. code-block:: sh
+
+   $ pip install mnemonic
 
 Usage examples
 --------------
@@ -75,3 +76,5 @@ Given the word list, calculate original entropy:
 .. code-block:: python
 
    entropy = mnemo.to_entropy(words)
+
+.. _BIP-0039: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ python-mnemonic
 Reference implementation of BIP-0039: Mnemonic code for generating
 deterministic keys
 
+Maintained by `Trezor <https://trezor.io>`_. See the `GitHub repository <https://github.com/trezor/python-mnemonic>`_ for source code and issue tracking.
+
 Abstract
 --------
 
@@ -76,5 +78,37 @@ Given the word list, calculate original entropy:
 .. code-block:: python
 
    entropy = mnemo.to_entropy(words)
+
+Command-line interface
+----------------------
+
+The ``mnemonic`` command provides CLI access to the library:
+
+.. code-block:: sh
+
+   $ mnemonic create --help
+   $ mnemonic check --help
+   $ mnemonic to-seed --help
+
+Generate a new mnemonic phrase:
+
+.. code-block:: sh
+
+   $ mnemonic create
+   $ mnemonic create -s 256 -l english -p "my passphrase"
+
+Validate a mnemonic phrase:
+
+.. code-block:: sh
+
+   $ mnemonic check abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+   $ echo "abandon abandon ..." | mnemonic check
+
+Derive seed from a mnemonic phrase:
+
+.. code-block:: sh
+
+   $ mnemonic to-seed abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+   $ mnemonic to-seed -p "my passphrase" word1 word2 ...
 
 .. _BIP-0039: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki

--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,10 @@ Generate a new mnemonic phrase:
 
    $ mnemonic create
    $ mnemonic create -s 256 -l english -p "my passphrase"
+   $ mnemonic create -s 256 -l english
+   $ mnemonic create -P                  # prompt for passphrase (hidden input)
+   $ mnemonic create --hide-seed         # only output mnemonic, not the seed
+   $ MNEMONIC_PASSPHRASE="secret" mnemonic create
 
 Validate a mnemonic phrase:
 
@@ -110,5 +114,7 @@ Derive seed from a mnemonic phrase:
 
    $ mnemonic to-seed abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
    $ mnemonic to-seed -p "my passphrase" word1 word2 ...
+   $ mnemonic to-seed -P word1 word2 ...   # prompt for passphrase (hidden input)
+   $ MNEMONIC_PASSPHRASE="secret" mnemonic to-seed word1 word2 ...
 
 .. _BIP-0039: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ include = [
 
 [tool.poetry.dependencies]
 python = ">=3.8.1"
+click = "^8.0"
+
+[tool.poetry.scripts]
+mnemonic = "mnemonic.cli:cli"
 
 [tool.poetry.group.dev.dependencies]
 isort = "^5.13.2"

--- a/src/mnemonic/cli.py
+++ b/src/mnemonic/cli.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 
 from mnemonic import Mnemonic
@@ -5,6 +7,7 @@ from mnemonic import Mnemonic
 
 @click.group()
 def cli() -> None:
+    """BIP-39 mnemonic phrase generator and validator."""
     pass
 
 
@@ -14,28 +17,99 @@ def cli() -> None:
     "--language",
     default="english",
     type=str,
-    help="",
+    help="Language for the mnemonic wordlist.",
 )
 @click.option(
     "-s",
     "--strength",
     default=128,
     type=int,
-    help="",
+    help="Entropy strength in bits (128, 160, 192, 224, or 256).",
 )
-@click.option("-p", "--passphrase", default="", type=str, help="")
+@click.option(
+    "-p",
+    "--passphrase",
+    default="",
+    type=str,
+    help="Optional passphrase for seed derivation.",
+)
 def create(
     language: str,
     passphrase: str,
     strength: int,
 ) -> None:
-    """ """
+    """Generate a new mnemonic phrase and its derived seed."""
     mnemo = Mnemonic(language)
     words = mnemo.generate(strength)
     seed = mnemo.to_seed(words, passphrase)
-    click.secho("SUCCESS!", fg="green", bold=True)
     click.echo(f"Mnemonic: {words}")
     click.echo(f"Seed: {seed.hex()}")
+
+
+@cli.command()
+@click.option(
+    "-l",
+    "--language",
+    default=None,
+    type=str,
+    help="Language for the mnemonic wordlist. Auto-detected if not specified.",
+)
+@click.argument("words", nargs=-1)
+def check(language: str | None, words: tuple[str, ...]) -> None:
+    """Validate a mnemonic phrase's checksum.
+
+    WORDS can be provided as arguments or piped via stdin.
+    """
+    if words:
+        mnemonic = " ".join(words)
+    else:
+        mnemonic = sys.stdin.read().strip()
+
+    if not mnemonic:
+        click.secho("Error: No mnemonic provided.", fg="red", err=True)
+        sys.exit(1)
+
+    try:
+        if language is None:
+            language = Mnemonic.detect_language(mnemonic)
+        mnemo = Mnemonic(language)
+        if mnemo.check(mnemonic):
+            click.secho("Valid mnemonic.", fg="green")
+            sys.exit(0)
+        else:
+            click.secho("Invalid mnemonic checksum.", fg="red", err=True)
+            sys.exit(1)
+    except Exception as e:
+        click.secho(f"Error: {e}", fg="red", err=True)
+        sys.exit(1)
+
+
+@cli.command("to-seed")
+@click.option(
+    "-p",
+    "--passphrase",
+    default="",
+    type=str,
+    help="Optional passphrase for seed derivation.",
+)
+@click.argument("words", nargs=-1)
+def to_seed(passphrase: str, words: tuple[str, ...]) -> None:
+    """Derive a seed from a mnemonic phrase.
+
+    WORDS can be provided as arguments or piped via stdin.
+    Outputs the 64-byte seed in hexadecimal format.
+    """
+    if words:
+        mnemonic = " ".join(words)
+    else:
+        mnemonic = sys.stdin.read().strip()
+
+    if not mnemonic:
+        click.secho("Error: No mnemonic provided.", fg="red", err=True)
+        sys.exit(1)
+
+    seed = Mnemonic.to_seed(mnemonic, passphrase)
+    click.echo(seed.hex())
 
 
 if __name__ == "__main__":

--- a/src/mnemonic/cli.py
+++ b/src/mnemonic/cli.py
@@ -3,6 +3,7 @@ import sys
 import click
 
 from mnemonic import Mnemonic
+from mnemonic.mnemonic import ConfigurationError
 
 
 @click.group()
@@ -22,28 +23,56 @@ def cli() -> None:
 @click.option(
     "-s",
     "--strength",
-    default=128,
-    type=int,
-    help="Entropy strength in bits (128, 160, 192, 224, or 256).",
+    default="128",
+    type=click.Choice(["128", "160", "192", "224", "256"]),
+    help="Entropy strength in bits.",
 )
 @click.option(
     "-p",
     "--passphrase",
     default="",
+    envvar="MNEMONIC_PASSPHRASE",
     type=str,
-    help="Optional passphrase for seed derivation.",
+    help="Passphrase for seed derivation. Can also be set via MNEMONIC_PASSPHRASE env var.",
+)
+@click.option(
+    "-P",
+    "--prompt-passphrase",
+    is_flag=True,
+    default=False,
+    help="Prompt for passphrase with hidden input (secure).",
+)
+@click.option(
+    "--hide-seed",
+    is_flag=True,
+    default=False,
+    help="Do not display the derived seed.",
 )
 def create(
     language: str,
     passphrase: str,
-    strength: int,
+    prompt_passphrase: bool,
+    strength: str,
+    hide_seed: bool,
 ) -> None:
     """Generate a new mnemonic phrase and its derived seed."""
-    mnemo = Mnemonic(language)
-    words = mnemo.generate(strength)
-    seed = mnemo.to_seed(words, passphrase)
-    click.echo(f"Mnemonic: {words}")
-    click.echo(f"Seed: {seed.hex()}")
+    if prompt_passphrase:
+        if passphrase:
+            click.secho(
+                "Warning: --prompt-passphrase overrides -p/MNEMONIC_PASSPHRASE.",
+                fg="yellow",
+                err=True,
+            )
+        passphrase = click.prompt("Passphrase", default="", hide_input=True)
+    try:
+        mnemo = Mnemonic(language)
+        words = mnemo.generate(int(strength))
+        click.echo(f"Mnemonic: {words}")
+        if not hide_seed:
+            seed = mnemo.to_seed(words, passphrase)
+            click.echo(f"Seed: {seed.hex()}")
+    except ConfigurationError as e:
+        raise click.ClickException(str(e))
 
 
 @cli.command()
@@ -66,8 +95,7 @@ def check(language: str | None, words: tuple[str, ...]) -> None:
         mnemonic = sys.stdin.read().strip()
 
     if not mnemonic:
-        click.secho("Error: No mnemonic provided.", fg="red", err=True)
-        sys.exit(1)
+        raise click.ClickException("No mnemonic provided.")
 
     try:
         if language is None:
@@ -75,13 +103,12 @@ def check(language: str | None, words: tuple[str, ...]) -> None:
         mnemo = Mnemonic(language)
         if mnemo.check(mnemonic):
             click.secho("Valid mnemonic.", fg="green")
-            sys.exit(0)
         else:
-            click.secho("Invalid mnemonic checksum.", fg="red", err=True)
-            sys.exit(1)
-    except Exception as e:
-        click.secho(f"Error: {e}", fg="red", err=True)
-        sys.exit(1)
+            raise click.ClickException("Invalid mnemonic checksum.")
+    except ConfigurationError as e:
+        raise click.ClickException(str(e))
+    except (ValueError, LookupError) as e:
+        raise click.ClickException(str(e))
 
 
 @cli.command("to-seed")
@@ -89,11 +116,19 @@ def check(language: str | None, words: tuple[str, ...]) -> None:
     "-p",
     "--passphrase",
     default="",
+    envvar="MNEMONIC_PASSPHRASE",
     type=str,
-    help="Optional passphrase for seed derivation.",
+    help="Passphrase for seed derivation. Can also be set via MNEMONIC_PASSPHRASE env var.",
+)
+@click.option(
+    "-P",
+    "--prompt-passphrase",
+    is_flag=True,
+    default=False,
+    help="Prompt for passphrase with hidden input (secure).",
 )
 @click.argument("words", nargs=-1)
-def to_seed(passphrase: str, words: tuple[str, ...]) -> None:
+def to_seed(passphrase: str, prompt_passphrase: bool, words: tuple[str, ...]) -> None:
     """Derive a seed from a mnemonic phrase.
 
     WORDS can be provided as arguments or piped via stdin.
@@ -105,11 +140,28 @@ def to_seed(passphrase: str, words: tuple[str, ...]) -> None:
         mnemonic = sys.stdin.read().strip()
 
     if not mnemonic:
-        click.secho("Error: No mnemonic provided.", fg="red", err=True)
-        sys.exit(1)
+        raise click.ClickException("No mnemonic provided.")
 
-    seed = Mnemonic.to_seed(mnemonic, passphrase)
-    click.echo(seed.hex())
+    if prompt_passphrase:
+        if passphrase:
+            click.secho(
+                "Warning: --prompt-passphrase overrides -p/MNEMONIC_PASSPHRASE.",
+                fg="yellow",
+                err=True,
+            )
+        passphrase = click.prompt("Passphrase", default="", hide_input=True)
+
+    try:
+        language = Mnemonic.detect_language(mnemonic)
+        mnemo = Mnemonic(language)
+        if not mnemo.check(mnemonic):
+            raise click.ClickException("Invalid mnemonic checksum.")
+        seed = mnemo.to_seed(mnemonic, passphrase)
+        click.echo(seed.hex())
+    except ConfigurationError as e:
+        raise click.ClickException(str(e))
+    except (ValueError, LookupError) as e:
+        raise click.ClickException(str(e))
 
 
 if __name__ == "__main__":

--- a/src/mnemonic/cli.py
+++ b/src/mnemonic/cli.py
@@ -1,0 +1,42 @@
+import click
+
+from mnemonic import Mnemonic
+
+
+@click.group()
+def cli() -> None:
+    pass
+
+
+@cli.command()
+@click.option(
+    "-l",
+    "--language",
+    default="english",
+    type=str,
+    help="",
+)
+@click.option(
+    "-s",
+    "--strength",
+    default=128,
+    type=int,
+    help="",
+)
+@click.option("-p", "--passphrase", default="", type=str, help="")
+def create(
+    language: str,
+    passphrase: str,
+    strength: int,
+) -> None:
+    """ """
+    mnemo = Mnemonic(language)
+    words = mnemo.generate(strength)
+    seed = mnemo.to_seed(words, passphrase)
+    click.secho("SUCCESS!", fg="green", bold=True)
+    click.echo(f"Mnemonic: {words}")
+    click.echo(f"Seed: {seed.hex()}")
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary

This PR adds a command-line interface to the python-mnemonic library, making it easy to generate, validate, and derive seeds from BIP-39 mnemonic phrases directly from the terminal.

### New Commands

- **`mnemonic create`** - Generate a new mnemonic phrase and its derived seed
  - `-l, --language` - Wordlist language (default: english)
  - `-s, --strength` - Entropy bits: 128, 160, 192, 224, or 256 (default: 128)
  - `-p, --passphrase` - Optional passphrase for seed derivation

- **`mnemonic check`** - Validate a mnemonic phrase's checksum
  - `-l, --language` - Wordlist language (auto-detected if not specified)
  - Accepts words as arguments or via stdin
  - Exit code 0 for valid, 1 for invalid

- **`mnemonic to-seed`** - Derive a 64-byte seed from a mnemonic phrase
  - `-p, --passphrase` - Optional passphrase for seed derivation
  - Accepts words as arguments or via stdin
  - Outputs seed in hexadecimal format

### Usage Examples

```bash
# Generate a new mnemonic
mnemonic create
mnemonic create -s 256 -l english -p "my passphrase"

# Validate a mnemonic
mnemonic check word1 word2 word3 ...
echo "word1 word2 ..." | mnemonic check

# Derive seed
mnemonic to-seed word1 word2 word3 ...
echo "word1 word2 ..." | mnemonic to-seed -p "passphrase"
```

## Test Plan

- [x] `mnemonic create` generates valid mnemonic and seed
- [x] `mnemonic check` returns exit 0 for valid mnemonic
- [x] `mnemonic check` returns exit 1 for invalid mnemonic
- [x] `mnemonic to-seed` outputs correct seed in hex format
- [x] Stdin input works for `check` and `to-seed`
- [x] Language auto-detection works in `check`
- [x] All existing tests pass
- [x] Style checks pass (black, flake8, pyright)