### PR TITLE
to_entropy() cannot read the japanese mnemonics to_mnemonic() writes

### DIFF
--- a/src/mnemonic/mnemonic.py
+++ b/src/mnemonic/mnemonic.py
@@ -152,7 +152,7 @@ class Mnemonic(object):
     # Adapted from <http://tinyurl.com/oxmn476>
     def to_entropy(self, words: list[str] | str) -> bytearray:
         if not isinstance(words, list):
-            words = words.split(" ")
+            words = self.normalize_string(words).split()
         if len(words) not in [12, 15, 18, 21, 24]:
             raise ValueError(
                 "Number of words must be one of the following: [12, 15, 18, 21, 24], but it is not (%d)."
@@ -210,7 +210,7 @@ class Mnemonic(object):
         return self.delimiter.join(result)
 
     def check(self, mnemonic: str) -> bool:
-        mnemonic_list = self.normalize_string(mnemonic).split(" ")
+        mnemonic_list = self.normalize_string(mnemonic).split()
         # list of valid mnemonic lengths
         if len(mnemonic_list) not in [12, 15, 18, 21, 24]:
             return False
@@ -241,11 +241,11 @@ class Mnemonic(object):
                 return prefix
 
     def expand(self, mnemonic: str) -> str:
-        return " ".join(map(self.expand_word, mnemonic.split(" ")))
+        return " ".join(map(self.expand_word, mnemonic.split()))
 
     @classmethod
     def to_seed(cls, mnemonic: str, passphrase: str = "") -> bytes:
-        mnemonic = cls.normalize_string(mnemonic)
+        mnemonic = " ".join(cls.normalize_string(mnemonic).split())
         passphrase = cls.normalize_string(passphrase)
         passphrase = "mnemonic" + passphrase
         mnemonic_bytes = mnemonic.encode("utf-8")

--- a/tests/test_mnemonic.py
+++ b/tests/test_mnemonic.py
@@ -141,12 +141,58 @@ class MnemonicTest(unittest.TestCase):
             "action", m.expand_word("acti")
         )  # unique prefix expanded to word in list
 
+    def test_japanese_vectors_to_entropy(self) -> None:
+        # the ideographic space separates words on every path, not only in
+        # to_mnemonic; see #110, whose fix split on self.delimiter and was
+        # reverted because NFKD had already turned U+3000 into a space
+        with open("vectors.json", "r") as f:
+            vectors = json.load(f)
+        m = Mnemonic("japanese")
+        for v in vectors["japanese"]:
+            self.assertIn("\u3000", v[1])
+            entropy = bytes(m.to_entropy(v[1]))
+            self.assertEqual(v[0], entropy.hex())
+            self.assertEqual(v[1], m.to_mnemonic(entropy))
+
+    def test_whitespace_runs(self) -> None:
+        # check(), to_entropy() and to_seed() read the same separator: any
+        # run of unicode whitespace, once NFKD has been applied
+        m = Mnemonic("english")
+        canonical = "abandon " * 11 + "about"
+        entropy = m.to_entropy(canonical)
+        seed = Mnemonic.to_seed(canonical)
+        for variant in (
+            " " + canonical,
+            canonical + "\n",
+            canonical.replace("abandon about", "abandon  about"),
+            canonical.replace(" ", "\t"),
+            canonical.replace(" ", "\u3000"),
+            canonical.replace(" ", "\u00a0"),
+        ):
+            self.assertIs(m.check(variant), True)
+            self.assertEqual(entropy, m.to_entropy(variant))
+            self.assertEqual(seed, Mnemonic.to_seed(variant))
+
     def test_expand(self) -> None:
         m = Mnemonic("english")
         self.assertEqual("access", m.expand("access"))
         self.assertEqual(
             "access access acb acc act action", m.expand("access acce acb acc act acti")
         )
+
+    def test_expand_whitespace(self) -> None:
+        # expand() separates words the way check() and to_entropy() do: on
+        # any run of unicode whitespace. Splitting on " " alone leaves a
+        # tab-separated sentence one token, which expand_word can only hand
+        # back unexpanded, and a japanese sentence with it
+        m = Mnemonic("english")
+        self.assertEqual("access action", m.expand("acce\tacti"))
+        self.assertEqual("access action", m.expand("acce  acti"))
+
+        # the words come back joined with a plain space, as expand() has
+        # always joined them; to_mnemonic() is what writes the delimiter
+        m = Mnemonic("japanese")
+        self.assertEqual("あいこくしん あおぞら", m.expand("あいこくし　あおぞら"))
 
 
 def __main__() -> None:


### PR DESCRIPTION
`Mnemonic("japanese")` joins words with U+3000, the ideographic space
([`#L73`](https://github.com/trezor/python-mnemonic/blob/b57a5ad77a981e743f4167ab2f7927a55c1e82a8/src/mnemonic/mnemonic.py#L73),
[`#L210`](https://github.com/trezor/python-mnemonic/blob/b57a5ad77a981e743f4167ab2f7927a55c1e82a8/src/mnemonic/mnemonic.py#L210)),
as BIP39's Japanese vectors do. `to_entropy` and `expand` split on `" "`, so
they see a single word: the first raises, the second returns the sentence
unchanged. `check` accepts it, because it normalizes first and NFKD maps
U+3000 to U+0020.

The README's own steps are the reproduction. On master, python 3.12:

```pycon
>>> from mnemonic import Mnemonic
>>> m = Mnemonic("japanese")
>>> words = m.generate(strength=256)   # README: "Generate word list"
>>> m.check(words)
True
>>> m.to_entropy(words)                # README: "calculate original entropy"
Traceback (most recent call last):
  ...
ValueError: Number of words must be one of the following: [12, 15, 18, 21, 24], but it is not (1).
```

That block is a doctest, and passes as written on master; with this patch
applied it fails, because `to_entropy` then returns the entropy. On
`vectors.json`, `check` accepts all 288 mnemonics while `to_entropy` fails
on all 24 Japanese ones and none of the other 264.

#110 fixed this by splitting on `self.delimiter`; it was merged as
`71cf5203` and reverted as `df3e1500` for failing CI. That direction cannot
work in `check`, which normalizes *before* splitting: after NFKD there is no
U+3000 left to split on, so every Japanese mnemonic fails validation
instead. Hence any run of whitespace, read after normalization — which is
what `detect_language` already does.

The fourth changed line applies the same rule to `to_seed`, whose NFKD-only
reading silently stretches a *different seed* out of the input `check`
rejects: a leading space, a trailing newline, a tab. If that is unwanted,
drop it along with the last assertion of `test_whitespace_runs`; the other
three still fix the Japanese bug.

Compatibility: all 288 vectors are unchanged — `test_vectors` asserts
mnemonic, seed and xprv for each, and passes. No input `check` accepts today
derives a different seed; what changes is input it rejects, which now
derives the canonical one. The passphrase is untouched, its whitespace being
part of the secret.

CI, since #110 was reverted for failing it: `python tests/test_mnemonic.py`
is `OK` on python 3.8 through 3.14 and on pypy 3.11, and `black --check`,
`isort --check-only`, `flake8` and `pyright` report nothing on
`src tests tools`.

*Written with machine assistance and reviewed against master `b57a5ad`
before filing. Found while checking btclib's BIP39 reading against this
implementation: btclib-org/btclib#258.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
